### PR TITLE
fix: use object format for center coordinates in Multi-Character generation

### DIFF
--- a/src/novelai/_utils/converter.py
+++ b/src/novelai/_utils/converter.py
@@ -35,7 +35,9 @@ def _convert_characters_to_char_prompts(
         api_types.CharacterPrompt(
             prompt=char.prompt,
             uc=char.negative_prompt,
-            center=(float(char.position[0]), float(char.position[1])),
+            center=api_types.CenterPoint(
+                x=float(char.position[0]), y=float(char.position[1])
+            ),
             enabled=char.enabled,
         )
         for char in characters
@@ -58,7 +60,11 @@ def _convert_characters_to_char_captions(
     return [
         api_types.V4CharacterCaption(
             char_caption=char.negative_prompt if is_negative else char.prompt,
-            centers=[(float(char.position[0]), float(char.position[1]))],
+            centers=[
+                api_types.CenterPoint(
+                    x=float(char.position[0]), y=float(char.position[1])
+                )
+            ],
         )
         for char in characters
         if char.enabled

--- a/src/novelai/types/api/image.py
+++ b/src/novelai/types/api/image.py
@@ -9,12 +9,19 @@ from pydantic import BaseModel, ConfigDict, Field
 from ...constants import StreamingType
 
 
+class CenterPoint(BaseModel):
+    """Center point coordinates in object format for API"""
+
+    x: float = Field(..., description="X coordinate")
+    y: float = Field(..., description="Y coordinate")
+
+
 class CharacterPrompt(BaseModel):
     """Character-specific prompt with positioning"""
 
     prompt: str = Field(..., description="Character prompt")
     uc: str = Field(..., description="Undesired content for character")
-    center: tuple[float, float] = Field(..., description="Character center position")
+    center: CenterPoint = Field(..., description="Character center position")
     enabled: bool = Field(default=True, description="Enable this character prompt")
 
 
@@ -31,7 +38,7 @@ class EncodeVibeRequest(BaseModel):
 class V4CharacterCaption(BaseModel):
     """Character caption with positioning for V4"""
 
-    centers: list[tuple[float, float]] | None = Field(
+    centers: list[CenterPoint] | None = Field(
         None, description="Character center coordinates"
     )
     char_caption: str | None = Field(

--- a/website/docs/examples/multi-character.md
+++ b/website/docs/examples/multi-character.md
@@ -23,6 +23,7 @@ params = GenerateImageParams(
     # General prompt can be used, but details should be in characters list
     prompt="two people standing together, holding hands, best quality",
     model="nai-diffusion-4-5-full",
+    size=(832, 1216),  # Size must be explicitly specified
     characters=characters,
 )
 ```


### PR DESCRIPTION
## Description

Fix Multi-Character generation returning 400 API errors by correcting the center coordinate format.

### Problem
When generating images with multiple characters using the SDK, the API returned a 400 error:
```
{"statusCode":400,"message":"Error decoding request body"}
```

### Root Cause
The SDK was sending center coordinates in **array format** `[x, y]`, but the NovelAI API expects **object format** `{"x": float, "y": float}` as documented in the [official API documentation](https://image.novelai.net/docs/index.html).

| Field | SDK (before) | API (expected) |
|-------|--------------|----------------|
| `CharacterPrompt.center` | `[0.5, 0.5]` | `{"x": 0.5, "y": 0.5}` |
| `V4CharacterCaption.centers` | `[[0.5, 0.5]]` | `[{"x": 0.5, "y": 0.5}]` |

### Changes
- Add `CenterPoint` model with `x` and `y` fields
- Update `CharacterPrompt.center` to use `CenterPoint`
- Update `V4CharacterCaption.centers` to use `list[CenterPoint]`
- Add required `size` parameter to multi-character documentation example

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition or update
- [ ] 🔧 Configuration/Build changes

## Checklist

- [x] I have read the [Contributing Guidelines](../README.md#contributing)
- [x] I have run pre-commit checks (`uv run poe pre-commit`)
- [x] I have added/updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] All existing tests pass

## Screenshots / Examples

```python
from novelai.types import Character, GenerateImageParams

characters = [
    Character(
        prompt="1girl, red hair, blue eyes, school uniform",
        enabled=True,
        position=(0.2, 0.5),
    ),
    Character(
        prompt="1boy, black hair, green eyes, casual clothes",
        enabled=True,
        position=(0.8, 0.5),
    ),
]

params = GenerateImageParams(
    prompt="two people standing together, holding hands, best quality",
    model="nai-diffusion-4-5-full",
    size=(832, 1216),  # Size must be explicitly specified
    characters=characters,
)
```

<img width="208" height="304" alt="test_detailed_1" src="https://github.com/user-attachments/assets/ac047562-19dd-4676-90c3-dd7f16446d9e" />

## Additional Notes

- Verified by comparing SDK request format with Web UI request captured via browser developer tools
- Successfully generated images with both male and female characters appearing correctly
